### PR TITLE
[BUS-857] - Breadcrumbs

### DIFF
--- a/components/Checkout/CheckoutLineItem.vue
+++ b/components/Checkout/CheckoutLineItem.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import type { Schemas } from '@shopware/api-client/api-types';
 import { ApiClientError } from '@shopware/api-client';
-import { getSmallestThumbnailUrl, getProductRoute } from '@shopware-pwa/helpers-next';
+const { getProductRoute } = useProductRoute();
+const { getProductCover } = useMedia();
 const { pushError, pushSuccess } = useNotifications();
 
 const props = defineProps<{
@@ -10,6 +11,8 @@ const props = defineProps<{
 
 const { lineItem } = toRefs(props);
 const isLoading = ref(false);
+
+const lineItemCover = getProductCover(lineItem.value.cover, 'xs');
 
 const { getFormattedPrice } = usePrice();
 const { refreshCart } = useCart();
@@ -89,7 +92,8 @@ const debounceUpdate = useDebounceFn(updateQuantity, 600);
             :to="getProductRoute(lineItem)"
         >
             <img
-                :src="getSmallestThumbnailUrl(lineItem.cover)"
+                :src="lineItemCover.url"
+                :alt="lineItemCover.alt"
                 class="h-full w-full object-cover object-center"
             />
         </NuxtLink>

--- a/components/Checkout/CheckoutSummary.vue
+++ b/components/Checkout/CheckoutSummary.vue
@@ -24,6 +24,11 @@ const calculatedTaxes = computed(() => {
     <div class="rounded-md bg-gray-light p-4">
         <h2 class="pb-4">Cart summary</h2>
         <template v-if="!reducedDisplay">
+            <CheckoutSummaryValues
+                label="net"
+                :value="netPrice"
+            />
+
             <template
                 v-for="(calculatedTax, index) in calculatedTaxes"
                 :key="`calculated-tax-${index}`"
@@ -33,11 +38,6 @@ const calculatedTaxes = computed(() => {
                     :value="calculatedTax.tax"
                 />
             </template>
-
-            <CheckoutSummaryValues
-                label="net"
-                :value="netPrice"
-            />
 
             <CheckoutSummaryValues
                 label="shipping"

--- a/components/FrontendDetailPage.vue
+++ b/components/FrontendDetailPage.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import { getCategoryBreadcrumbs } from "@shopware-pwa/helpers-next";
+const { getProductRoute } = useProductRoute();
+
 const props = defineProps<{
     navigationId: string;
 }>();
@@ -26,6 +29,18 @@ if (!productResponse.value) {
 }
 
 const { product } = useProduct(productResponse.value.product, productResponse.value.configurator);
+
+const breadcrumbs = getCategoryBreadcrumbs(
+    productResponse.value.product.seoCategory,
+);
+
+// add product as last breadcrumb entry on pdp
+breadcrumbs.push({
+    name: product.value.translated.name,
+    path: getProductRoute(product.value)
+});
+
+useBreadcrumbs(breadcrumbs);
 </script>
 
 <template>

--- a/components/FrontendDetailPage.vue
+++ b/components/FrontendDetailPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { getCategoryBreadcrumbs } from "@shopware-pwa/helpers-next";
+import { getCategoryBreadcrumbs } from '@shopware-pwa/helpers-next';
 const { getProductRoute } = useProductRoute();
 
 const props = defineProps<{
@@ -30,17 +30,14 @@ if (!productResponse.value) {
 
 const { product } = useProduct(productResponse.value.product, productResponse.value.configurator);
 
-const breadcrumbs = getCategoryBreadcrumbs(
-    productResponse.value.product.seoCategory,
-    {
-        startIndex: 1,
-    }
-);
+const breadcrumbs = getCategoryBreadcrumbs(productResponse.value.product.seoCategory, {
+    startIndex: 1,
+});
 
 // add product as last breadcrumb entry on pdp
 breadcrumbs.push({
     name: product.value.translated.name,
-    path: getProductRoute(product.value)
+    path: getProductRoute(product.value),
 });
 
 useBreadcrumbs(breadcrumbs);

--- a/components/FrontendDetailPage.vue
+++ b/components/FrontendDetailPage.vue
@@ -32,6 +32,9 @@ const { product } = useProduct(productResponse.value.product, productResponse.va
 
 const breadcrumbs = getCategoryBreadcrumbs(
     productResponse.value.product.seoCategory,
+    {
+        startIndex: 1,
+    }
 );
 
 // add product as last breadcrumb entry on pdp

--- a/components/FrontendLandingPage.vue
+++ b/components/FrontendLandingPage.vue
@@ -14,6 +14,18 @@ const { data: landingResponse } = await useAsyncData('landing' + props.navigatio
 if (!landingResponse.value) {
     throw createError({ statusCode: 404, message: 'page not found' });
 }
+
+useBreadcrumbs([
+    // TODO: Replace with dynamic home page name
+    {
+        name: 'Startseite',
+        path: '/'
+    },
+    {
+        name: landingResponse.value.translated.name,
+        path: landingResponse.value.url
+    }
+]);
 </script>
 
 <template>

--- a/components/FrontendLandingPage.vue
+++ b/components/FrontendLandingPage.vue
@@ -18,8 +18,8 @@ if (!landingResponse.value) {
 useBreadcrumbs([
     {
         name: landingResponse.value.translated.name,
-        path: landingResponse.value.url
-    }
+        path: landingResponse.value.url,
+    },
 ]);
 </script>
 

--- a/components/FrontendLandingPage.vue
+++ b/components/FrontendLandingPage.vue
@@ -16,11 +16,6 @@ if (!landingResponse.value) {
 }
 
 useBreadcrumbs([
-    // TODO: Replace with dynamic home page name
-    {
-        name: 'Startseite',
-        path: '/'
-    },
     {
         name: landingResponse.value.translated.name,
         path: landingResponse.value.url

--- a/components/FrontendNavigationPage.vue
+++ b/components/FrontendNavigationPage.vue
@@ -25,6 +25,9 @@ const { category } = useCategory(categoryResponse);
 
 const breadcrumbs = getCategoryBreadcrumbs(
     categoryResponse.value,
+    {
+        startIndex: 1,
+    }
 );
 
 useBreadcrumbs(breadcrumbs);

--- a/components/FrontendNavigationPage.vue
+++ b/components/FrontendNavigationPage.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { getCategoryBreadcrumbs } from "@shopware-pwa/helpers-next";
+
 const props = defineProps<{
     navigationId: string;
 }>();
@@ -20,6 +22,12 @@ if (!categoryResponse.value) {
 }
 
 const { category } = useCategory(categoryResponse);
+
+const breadcrumbs = getCategoryBreadcrumbs(
+    categoryResponse.value,
+);
+
+useBreadcrumbs(breadcrumbs);
 </script>
 
 <template>

--- a/components/FrontendNavigationPage.vue
+++ b/components/FrontendNavigationPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { getCategoryBreadcrumbs } from "@shopware-pwa/helpers-next";
+import { getCategoryBreadcrumbs } from '@shopware-pwa/helpers-next';
 
 const props = defineProps<{
     navigationId: string;
@@ -23,12 +23,9 @@ if (!categoryResponse.value) {
 
 const { category } = useCategory(categoryResponse);
 
-const breadcrumbs = getCategoryBreadcrumbs(
-    categoryResponse.value,
-    {
-        startIndex: 1,
-    }
-);
+const breadcrumbs = getCategoryBreadcrumbs(categoryResponse.value, {
+    startIndex: 1,
+});
 
 useBreadcrumbs(breadcrumbs);
 </script>

--- a/components/Layout/LayoutBreadcrumbs.vue
+++ b/components/Layout/LayoutBreadcrumbs.vue
@@ -8,6 +8,21 @@ const { breadcrumbs } = useBreadcrumbs();
         aria-label="Breadcrumb"
     >
         <ol class="inline-flex items-center gap-2">
+            <li class="inline-flex items-center gap-2">
+                <NuxtLink
+                    :to="'/'"
+                    class="inline-flex items-center text-sm font-medium"
+                >
+                    Home
+                </NuxtLink>
+
+                <FormKitIcon
+                    v-if="breadcrumbs?.length > 0"
+                    class="block h-4 w-4"
+                    icon="chevron-right"
+                />
+            </li>
+
             <li
                 v-for="(breadcrumb, index) in breadcrumbs"
                 :key="breadcrumb.path"

--- a/components/Layout/LayoutBreadcrumbs.vue
+++ b/components/Layout/LayoutBreadcrumbs.vue
@@ -11,7 +11,7 @@ const { breadcrumbs } = useBreadcrumbs();
             <li class="inline-flex items-center gap-2">
                 <NuxtLink
                     :to="'/'"
-                    class="inline-flex items-center text-sm font-medium hover:text-brand-primary last:text-brand-primary"
+                    class="inline-flex items-center text-sm font-medium last:text-brand-primary hover:text-brand-primary"
                 >
                     Home
                 </NuxtLink>
@@ -31,14 +31,14 @@ const { breadcrumbs } = useBreadcrumbs();
                 <NuxtLink
                     v-if="breadcrumb.path"
                     :to="breadcrumb.path"
-                    class="inline-flex items-center text-sm font-medium hover:text-brand-primary last:text-brand-primary"
+                    class="inline-flex items-center text-sm font-medium last:text-brand-primary hover:text-brand-primary"
                 >
                     {{ breadcrumb.name }}
                 </NuxtLink>
 
                 <span
                     v-else
-                    class="inline-flex items-center text-sm font-medium hover:text-brand-primary last:text-brand-primary"
+                    class="inline-flex items-center text-sm font-medium last:text-brand-primary hover:text-brand-primary"
                 >
                     {{ breadcrumb.name }}
                 </span>

--- a/components/Layout/LayoutBreadcrumbs.vue
+++ b/components/Layout/LayoutBreadcrumbs.vue
@@ -11,7 +11,7 @@ const { breadcrumbs } = useBreadcrumbs();
             <li class="inline-flex items-center gap-2">
                 <NuxtLink
                     :to="'/'"
-                    class="inline-flex items-center text-sm font-medium"
+                    class="inline-flex items-center text-sm font-medium hover:text-brand-primary last:text-brand-primary"
                 >
                     Home
                 </NuxtLink>
@@ -31,14 +31,14 @@ const { breadcrumbs } = useBreadcrumbs();
                 <NuxtLink
                     v-if="breadcrumb.path"
                     :to="breadcrumb.path"
-                    class="inline-flex items-center text-sm font-medium last:text-brand-primary"
+                    class="inline-flex items-center text-sm font-medium hover:text-brand-primary last:text-brand-primary"
                 >
                     {{ breadcrumb.name }}
                 </NuxtLink>
 
                 <span
                     v-else
-                    class="inline-flex items-center text-sm font-medium last:text-brand-primary"
+                    class="inline-flex items-center text-sm font-medium hover:text-brand-primary last:text-brand-primary"
                 >
                     {{ breadcrumb.name }}
                 </span>

--- a/components/Layout/LayoutBreadcrumbs.vue
+++ b/components/Layout/LayoutBreadcrumbs.vue
@@ -1,5 +1,16 @@
 <script setup lang="ts">
 const { breadcrumbs } = useBreadcrumbs();
+
+withDefaults(
+    defineProps<{
+        displayRoot?: boolean;
+        rootIcon?: string;
+    }>(),
+    {
+        displayRoot: true,
+        rootIcon: '',
+    },
+);
 </script>
 
 <template>
@@ -8,11 +19,19 @@ const { breadcrumbs } = useBreadcrumbs();
         aria-label="Breadcrumb"
     >
         <ol class="inline-flex items-center gap-2">
-            <li class="inline-flex items-center gap-2">
+            <li
+                v-if="displayRoot"
+                class="inline-flex items-center gap-2"
+            >
                 <NuxtLink
                     :to="'/'"
-                    class="inline-flex items-center text-sm font-medium last:text-brand-primary hover:text-brand-primary"
+                    class="inline-flex items-center gap-2 text-sm font-medium last:text-brand-primary hover:text-brand-primary"
                 >
+                    <FormKitIcon
+                        v-if="rootIcon"
+                        :icon="rootIcon"
+                        class="h-4 w-4"
+                    />
                     Home
                 </NuxtLink>
 

--- a/components/Layout/LayoutBreadcrumbs.vue
+++ b/components/Layout/LayoutBreadcrumbs.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+const { breadcrumbs } = useBreadcrumbs();
+</script>
+
+<template>
+    <nav
+        class="hidden lg:flex container mx-auto my-8"
+        aria-label="Breadcrumb"
+    >
+        <ol class="inline-flex items-center gap-2">
+            <li
+                v-for="(breadcrumb, index) in breadcrumbs"
+                :key="breadcrumb.path"
+                class="inline-flex items-center gap-2"
+            >
+                <NuxtLink
+                    v-if="breadcrumb.path"
+                    :to="breadcrumb.path"
+                    class="inline-flex items-center text-sm font-medium last:text-brand-primary"
+                >
+                    {{ breadcrumb.name }}
+                </NuxtLink>
+
+                <span
+                    v-else
+                    class="inline-flex items-center text-sm font-medium last:text-brand-primary"
+                >
+                  {{ breadcrumb.name }}
+                </span>
+
+                <FormKitIcon
+                    v-if="index < breadcrumbs.length - 1"
+                    class="block h-4 w-4"
+                    icon="chevron-right"
+                />
+            </li>
+        </ol>
+    </nav>
+</template>

--- a/components/Layout/LayoutBreadcrumbs.vue
+++ b/components/Layout/LayoutBreadcrumbs.vue
@@ -4,7 +4,7 @@ const { breadcrumbs } = useBreadcrumbs();
 
 <template>
     <nav
-        class="hidden lg:flex container mx-auto my-8"
+        class="container mx-auto my-8 hidden lg:flex"
         aria-label="Breadcrumb"
     >
         <ol class="inline-flex items-center gap-2">
@@ -40,7 +40,7 @@ const { breadcrumbs } = useBreadcrumbs();
                     v-else
                     class="inline-flex items-center text-sm font-medium last:text-brand-primary"
                 >
-                  {{ breadcrumb.name }}
+                    {{ breadcrumb.name }}
                 </span>
 
                 <FormKitIcon

--- a/components/Order/OrderLineItem.vue
+++ b/components/Order/OrderLineItem.vue
@@ -2,6 +2,7 @@
 import type { Schemas } from '@shopware/api-client/api-types';
 const { getFormattedPrice } = usePrice();
 const { getProductCover } = useMedia();
+const { getProductRoute } = useProductRoute();
 
 const props = defineProps<{
     lineItem: Schemas['LineItem'];
@@ -14,7 +15,7 @@ const lineItemCover = getProductCover(lineItem.value.cover, 'xs');
 
 <template>
     <div class="mr-4 h-24 w-24 flex-shrink-0 overflow-hidden rounded-md border border-gray-medium">
-        <NuxtLink :to="'/detail/' + lineItem.productId">
+        <NuxtLink :to="getProductRoute(lineItem)">
             <img
                 :src="lineItemCover.url"
                 :alt="lineItemCover.alt"
@@ -26,7 +27,7 @@ const lineItemCover = getProductCover(lineItem.value.cover, 'xs');
     <div class="flex flex-1 flex-col">
         <div>
             <div class="flex flex-col justify-between lg:flex-row">
-                <NuxtLink :to="'/detail/' + lineItem.productId">
+                <NuxtLink :to="getProductRoute(lineItem)">
                     <h3 class="text-base">
                         {{ lineItem?.label }}
                     </h3>

--- a/components/Order/OrderSummary.vue
+++ b/components/Order/OrderSummary.vue
@@ -11,10 +11,29 @@ defineProps<{
         <h2 class="pb-4">Order summary</h2>
 
         <CheckoutSummaryValues
-            :shipping-total="order.shippingTotal"
-            :total-price="order.price.totalPrice"
-            :calculated-taxes="order.price.calculatedTaxes"
-            :net-price="order.price.netPrice"
+            label="net"
+            :value="order.price.netPrice"
+        />
+
+        <template
+            v-for="(calculatedTax, index) in order.price.calculatedTaxes"
+            :key="`calculated-tax-${index}`"
+        >
+            <CheckoutSummaryValues
+                label="tax"
+                :value="calculatedTax.tax"
+            />
+        </template>
+
+        <CheckoutSummaryValues
+            label="shipping"
+            :value="order.shippingTotal"
+        />
+
+        <CheckoutSummaryValues
+            label="total"
+            :value="order.price.totalPrice"
+            :highlight="true"
         />
     </div>
 </template>

--- a/composables/useProductRoute.ts
+++ b/composables/useProductRoute.ts
@@ -2,7 +2,7 @@ import type { Schemas } from '@shopware/api-client/api-types';
 
 /**
  * Get product route information for Vue router.
- * This composable uses the referencedId of the product - thus making it compatible with objects of type Product, LineItem and OrderLineItem.
+ * This composable uses the referencedId of the product and the id as a fallback - thus making it compatible with objects of type Product, LineItem and OrderLineItem.
  * The original code is from the getProductRoute function of `@shopware-pwa/helpers-next`
  *
  * Returns product URL and route information for resolving SEO url.
@@ -14,7 +14,7 @@ export function useProductRoute() {
             path: getProductUrl(product),
             state: {
                 routeName: "frontend.detail.page",
-                foreignKey: product?.referencedId
+                foreignKey: product?.referencedId ?? product?.id
             }
         };
     };
@@ -27,5 +27,5 @@ function getProductUrl(product: Schemas.Product | Schemas.LineItem | Schemas.Ord
     if (!product)
         return "/";
     const seoUrl = (_b = (_a = product.seoUrls) == null ? void 0 : _a[0]) == null ? void 0 : _b.seoPathInfo;
-    return seoUrl ? `/${seoUrl}` : `/detail/${product.referencedId}`;
+    return seoUrl ? `/${seoUrl}` : `/detail/${product.referencedId ?? product.id}`;
 }

--- a/composables/useProductRoute.ts
+++ b/composables/useProductRoute.ts
@@ -1,0 +1,31 @@
+import type { Schemas } from '@shopware/api-client/api-types';
+
+/**
+ * Get product route information for Vue router.
+ * This composable uses the referencedId of the product - thus making it compatible with objects of type Product, LineItem and OrderLineItem.
+ * The original code is from the getProductRoute function of `@shopware-pwa/helpers-next`
+ *
+ * Returns product URL and route information for resolving SEO url.
+ * Use it in combination with `<RouterLink>` or `<NuxtLink>`.
+ */
+export function useProductRoute() {
+    const getProductRoute = (product: Schemas.Product | Schemas.LineItem | Schemas.OrderLineItem) => {
+        return {
+            path: getProductUrl(product),
+            state: {
+                routeName: "frontend.detail.page",
+                foreignKey: product?.referencedId
+            }
+        };
+    };
+
+    return { getProductRoute };
+}
+
+function getProductUrl(product: Schemas.Product | Schemas.LineItem | Schemas.OrderLineItem) {
+    let _a, _b;
+    if (!product)
+        return "/";
+    const seoUrl = (_b = (_a = product.seoUrls) == null ? void 0 : _a[0]) == null ? void 0 : _b.seoPathInfo;
+    return seoUrl ? `/${seoUrl}` : `/detail/${product.referencedId}`;
+}

--- a/composables/useProductRoute.ts
+++ b/composables/useProductRoute.ts
@@ -13,9 +13,9 @@ export function useProductRoute() {
         return {
             path: getProductUrl(product),
             state: {
-                routeName: "frontend.detail.page",
-                foreignKey: product?.referencedId ?? product?.id
-            }
+                routeName: 'frontend.detail.page',
+                foreignKey: product?.referencedId ?? product?.id,
+            },
         };
     };
 
@@ -24,8 +24,7 @@ export function useProductRoute() {
 
 function getProductUrl(product: Schemas.Product | Schemas.LineItem | Schemas.OrderLineItem) {
     let _a, _b;
-    if (!product)
-        return "/";
+    if (!product) return '/';
     const seoUrl = (_b = (_a = product.seoUrls) == null ? void 0 : _a[0]) == null ? void 0 : _b.seoPathInfo;
     return seoUrl ? `/${seoUrl}` : `/detail/${product.referencedId ?? product.id}`;
 }

--- a/composables/useStaticBreadcrumbs.ts
+++ b/composables/useStaticBreadcrumbs.ts
@@ -3,7 +3,7 @@
  * Options can be defined to e.g. display only parts of the hierarchy or to alter its structure.
  */
 export function useStaticBreadcrumbs() {
-    const checkoutBreadcrumbs = (index: number, orderId?: string) => {
+    const checkoutBreadcrumbs = ({ index, orderId }: { index: number; orderId?: string }) => {
         const breadcrumbs = [
             {
                 name: 'Cart',
@@ -22,7 +22,7 @@ export function useStaticBreadcrumbs() {
         return breadcrumbs.slice(0, index + 1);
     };
 
-    const accountBreadcrumbs = (type?: string) => {
+    const accountBreadcrumbs = ({ type }: { type?: string }) => {
         const breadcrumbs = [
             {
                 name: 'Account',

--- a/composables/useStaticBreadcrumbs.ts
+++ b/composables/useStaticBreadcrumbs.ts
@@ -1,0 +1,45 @@
+export function useStaticBreadcrumbs() {
+    const checkoutBreadcrumbs = (index: number, orderId?: string) => {
+        const breadcrumbs = [
+            {
+                name: "Cart",
+                path: "/checkout/cart",
+            },
+            {
+                name: "Checkout",
+                path: "/checkout/confirm",
+            },
+            {
+                name: "Order",
+                path: orderId ? "/checkout/finish/" + orderId : "/checkout/finish",
+            },
+        ];
+
+        return breadcrumbs.slice(0, index + 1);
+    };
+
+    const accountBreadcrumbs = (type?: string) => {
+        const breadcrumbs = [
+            {
+                name: "Account",
+                path: "/account",
+            }
+        ];
+
+        if (type ===  "login") {
+            breadcrumbs.push({
+                name: "Login",
+                path: "/account/login",
+            });
+        } else if (type === "register") {
+            breadcrumbs.push({
+                name: "Register",
+                path: "/account/register",
+            });
+        }
+
+        return breadcrumbs;
+    }
+
+    return { checkoutBreadcrumbs, accountBreadcrumbs };
+}

--- a/composables/useStaticBreadcrumbs.ts
+++ b/composables/useStaticBreadcrumbs.ts
@@ -6,16 +6,16 @@ export function useStaticBreadcrumbs() {
     const checkoutBreadcrumbs = (index: number, orderId?: string) => {
         const breadcrumbs = [
             {
-                name: "Cart",
-                path: "/checkout/cart",
+                name: 'Cart',
+                path: '/checkout/cart',
             },
             {
-                name: "Checkout",
-                path: "/checkout/confirm",
+                name: 'Checkout',
+                path: '/checkout/confirm',
             },
             {
-                name: "Order",
-                path: orderId ? "/checkout/finish/" + orderId : "/checkout/finish",
+                name: 'Order',
+                path: orderId ? '/checkout/finish/' + orderId : '/checkout/finish',
             },
         ];
 
@@ -25,25 +25,25 @@ export function useStaticBreadcrumbs() {
     const accountBreadcrumbs = (type?: string) => {
         const breadcrumbs = [
             {
-                name: "Account",
-                path: "/account",
-            }
+                name: 'Account',
+                path: '/account',
+            },
         ];
 
-        if (type ===  "login") {
+        if (type === 'login') {
             breadcrumbs.push({
-                name: "Login",
-                path: "/account/login",
+                name: 'Login',
+                path: '/account/login',
             });
-        } else if (type === "register") {
+        } else if (type === 'register') {
             breadcrumbs.push({
-                name: "Register",
-                path: "/account/register",
+                name: 'Register',
+                path: '/account/register',
             });
         }
 
         return breadcrumbs;
-    }
+    };
 
     return { checkoutBreadcrumbs, accountBreadcrumbs };
 }

--- a/composables/useStaticBreadcrumbs.ts
+++ b/composables/useStaticBreadcrumbs.ts
@@ -1,3 +1,7 @@
+/**
+ * This function returns the breadcrumb hierarchy for static pages, such as account and checkout.
+ * Options can be defined to e.g. display only parts of the hierarchy or to alter its structure.
+ */
 export function useStaticBreadcrumbs() {
     const checkoutBreadcrumbs = (index: number, orderId?: string) => {
         const breadcrumbs = [

--- a/formkit.config.ts
+++ b/formkit.config.ts
@@ -34,7 +34,9 @@ export default {
                     return icon;
                 } else {
                     // returns the icon from fontawesome as fallback (or undefined if not found)
-                    return fetch(`https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free/svgs/solid/${iconName}.svg`)
+                    return fetch(
+                        `https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free/svgs/solid/${iconName}.svg`,
+                    )
                         .then(async r => {
                             const icon = await r.text();
                             if (icon.startsWith('<svg')) {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -3,6 +3,7 @@ const customerStore = useCustomerStore();
 const { refreshCart } = useCart();
 const { loading } = storeToRefs(customerStore);
 useNotifications();
+useBreadcrumbs();
 
 customerStore.refreshContext();
 refreshCart();
@@ -21,6 +22,8 @@ refreshCart();
         v-show="!loading"
         class="mt-4 w-screen"
     >
+        <LayoutBreadcrumbs />
+
         <NuxtPage />
     </main>
 

--- a/pages/[...all].vue
+++ b/pages/[...all].vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { pascalCase } from 'scule';
 
+const { clearBreadcrumbs } = useBreadcrumbs();
 const { resolvePath } = useNavigationSearch();
 const route = useRoute();
 
@@ -26,6 +27,10 @@ const { componentExists } = useCmsUtils();
 if (!routeName.value) {
     throw createError({ statusCode: 404, message: 'page not found' });
 }
+
+onBeforeRouteLeave(() => {
+    clearBreadcrumbs();
+});
 </script>
 
 <template>

--- a/pages/account/index.vue
+++ b/pages/account/index.vue
@@ -1,17 +1,13 @@
 <script setup lang="ts">
 const customerStore = useCustomerStore();
+const { accountBreadcrumbs } = useStaticBreadcrumbs();
 
 const handleLogout = async () => {
     await customerStore.logout();
     navigateTo('/');
 };
 
-useBreadcrumbs([
-    {
-        name: "Account",
-        path: "/account",
-    },
-]);
+useBreadcrumbs(accountBreadcrumbs());
 </script>
 
 <template>

--- a/pages/account/index.vue
+++ b/pages/account/index.vue
@@ -5,6 +5,18 @@ const handleLogout = async () => {
     await customerStore.logout();
     navigateTo('/');
 };
+
+useBreadcrumbs([
+    // TODO: Replace with dynamic home page name
+    {
+        name: 'Startseite',
+        path: '/'
+    },
+    {
+        name: "Account",
+        path: "/account",
+    },
+]);
 </script>
 
 <template>

--- a/pages/account/index.vue
+++ b/pages/account/index.vue
@@ -7,11 +7,6 @@ const handleLogout = async () => {
 };
 
 useBreadcrumbs([
-    // TODO: Replace with dynamic home page name
-    {
-        name: 'Startseite',
-        path: '/'
-    },
     {
         name: "Account",
         path: "/account",

--- a/pages/account/index.vue
+++ b/pages/account/index.vue
@@ -7,7 +7,7 @@ const handleLogout = async () => {
     navigateTo('/');
 };
 
-useBreadcrumbs(accountBreadcrumbs());
+useBreadcrumbs(accountBreadcrumbs({}));
 </script>
 
 <template>

--- a/pages/account/login.vue
+++ b/pages/account/login.vue
@@ -1,3 +1,9 @@
+<script setup lang="ts">
+const { accountBreadcrumbs } = useStaticBreadcrumbs();
+
+useBreadcrumbs(accountBreadcrumbs("login"));
+</script>
+
 <template>
     <div class="flex w-full justify-center">
         <div class="w-60">

--- a/pages/account/login.vue
+++ b/pages/account/login.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 const { accountBreadcrumbs } = useStaticBreadcrumbs();
 
-useBreadcrumbs(accountBreadcrumbs('login'));
+useBreadcrumbs(accountBreadcrumbs({ type: 'login' }));
 </script>
 
 <template>

--- a/pages/account/login.vue
+++ b/pages/account/login.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 const { accountBreadcrumbs } = useStaticBreadcrumbs();
 
-useBreadcrumbs(accountBreadcrumbs("login"));
+useBreadcrumbs(accountBreadcrumbs('login'));
 </script>
 
 <template>

--- a/pages/account/register.vue
+++ b/pages/account/register.vue
@@ -1,3 +1,9 @@
+<script setup lang="ts">
+const { accountBreadcrumbs } = useStaticBreadcrumbs();
+
+useBreadcrumbs(accountBreadcrumbs("register"));
+</script>
+
 <template>
     <div class="flex w-full justify-center">
         <AccountRegister />

--- a/pages/account/register.vue
+++ b/pages/account/register.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 const { accountBreadcrumbs } = useStaticBreadcrumbs();
 
-useBreadcrumbs(accountBreadcrumbs('register'));
+useBreadcrumbs(accountBreadcrumbs({ type: 'register' }));
 </script>
 
 <template>

--- a/pages/account/register.vue
+++ b/pages/account/register.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 const { accountBreadcrumbs } = useStaticBreadcrumbs();
 
-useBreadcrumbs(accountBreadcrumbs("register"));
+useBreadcrumbs(accountBreadcrumbs('register'));
 </script>
 
 <template>

--- a/pages/checkout/cart.vue
+++ b/pages/checkout/cart.vue
@@ -1,12 +1,8 @@
 <script setup lang="ts">
 const { isEmpty, cartItems } = useCart();
+const { checkoutBreadcrumbs } = useStaticBreadcrumbs();
 
-useBreadcrumbs([
-    {
-        name: "Cart",
-        path: "/checkout/cart",
-    },
-]);
+useBreadcrumbs(checkoutBreadcrumbs(0));
 </script>
 
 <template>

--- a/pages/checkout/cart.vue
+++ b/pages/checkout/cart.vue
@@ -1,5 +1,17 @@
 <script setup lang="ts">
 const { isEmpty, cartItems } = useCart();
+
+useBreadcrumbs([
+    // TODO: Replace with dynamic home page name
+    {
+        name: 'Startseite',
+        path: '/'
+    },
+    {
+        name: "Warenkorb",
+        path: "/checkout/cart",
+    },
+]);
 </script>
 
 <template>

--- a/pages/checkout/cart.vue
+++ b/pages/checkout/cart.vue
@@ -2,7 +2,7 @@
 const { isEmpty, cartItems } = useCart();
 const { checkoutBreadcrumbs } = useStaticBreadcrumbs();
 
-useBreadcrumbs(checkoutBreadcrumbs(0));
+useBreadcrumbs(checkoutBreadcrumbs({ index: 0 }));
 </script>
 
 <template>

--- a/pages/checkout/cart.vue
+++ b/pages/checkout/cart.vue
@@ -2,13 +2,8 @@
 const { isEmpty, cartItems } = useCart();
 
 useBreadcrumbs([
-    // TODO: Replace with dynamic home page name
     {
-        name: 'Startseite',
-        path: '/'
-    },
-    {
-        name: "Warenkorb",
+        name: "Cart",
         path: "/checkout/cart",
     },
 ]);

--- a/pages/checkout/confirm.vue
+++ b/pages/checkout/confirm.vue
@@ -2,6 +2,7 @@
 import { ApiClientError } from '@shopware/api-client';
 
 const customerStore = useCustomerStore();
+const { checkoutBreadcrumbs } = useStaticBreadcrumbs();
 const { push } = useRouter();
 const { refreshCart, isEmpty, cartItems } = useCart();
 const { createOrder } = useCheckout();
@@ -23,16 +24,7 @@ const placeOrder = async () => {
     }
 };
 
-useBreadcrumbs([
-    {
-        name: "Cart",
-        path: "/checkout/cart",
-    },
-    {
-        name: "Checkout",
-        path: "/checkout/confirm",
-    },
-]);
+useBreadcrumbs(checkoutBreadcrumbs(1));
 </script>
 
 <template>

--- a/pages/checkout/confirm.vue
+++ b/pages/checkout/confirm.vue
@@ -24,7 +24,7 @@ const placeOrder = async () => {
     }
 };
 
-useBreadcrumbs(checkoutBreadcrumbs(1));
+useBreadcrumbs(checkoutBreadcrumbs({ index: 1 }));
 </script>
 
 <template>

--- a/pages/checkout/confirm.vue
+++ b/pages/checkout/confirm.vue
@@ -22,6 +22,22 @@ const placeOrder = async () => {
         }
     }
 };
+
+useBreadcrumbs([
+    // TODO: Replace with dynamic home page name
+    {
+        name: 'Startseite',
+        path: '/'
+    },
+    {
+        name: "Warenkorb",
+        path: "/checkout/cart",
+    },
+    {
+        name: "Kasse",
+        path: "/checkout/confirm",
+    },
+]);
 </script>
 
 <template>

--- a/pages/checkout/confirm.vue
+++ b/pages/checkout/confirm.vue
@@ -24,17 +24,12 @@ const placeOrder = async () => {
 };
 
 useBreadcrumbs([
-    // TODO: Replace with dynamic home page name
     {
-        name: 'Startseite',
-        path: '/'
-    },
-    {
-        name: "Warenkorb",
+        name: "Cart",
         path: "/checkout/cart",
     },
     {
-        name: "Kasse",
+        name: "Checkout",
         path: "/checkout/confirm",
     },
 ]);

--- a/pages/checkout/finish/[id].vue
+++ b/pages/checkout/finish/[id].vue
@@ -11,21 +11,16 @@ const formattedOrderDate = useDateFormat(order.orderDate, dateFormat, {
 });
 
 useBreadcrumbs([
-    // TODO: Replace with dynamic home page name
     {
-        name: 'Startseite',
-        path: '/'
-    },
-    {
-        name: "Warenkorb",
+        name: "Cart",
         path: "/checkout/cart",
     },
     {
-        name: "Kasse",
+        name: "Checkout",
         path: "/checkout/confirm",
     },
     {
-        name: "Bestellung",
+        name: "Order",
         path: "/checkout/finish/" + orderId,
     },
 ]);

--- a/pages/checkout/finish/[id].vue
+++ b/pages/checkout/finish/[id].vue
@@ -10,6 +10,26 @@ const formattedOrderDate = useDateFormat(order.orderDate, dateFormat, {
     locales: (typeof navigator !== 'undefined' && navigator.language) || 'en-US',
 });
 
+useBreadcrumbs([
+    // TODO: Replace with dynamic home page name
+    {
+        name: 'Startseite',
+        path: '/'
+    },
+    {
+        name: "Warenkorb",
+        path: "/checkout/cart",
+    },
+    {
+        name: "Kasse",
+        path: "/checkout/confirm",
+    },
+    {
+        name: "Bestellung",
+        path: "/checkout/finish/" + orderId,
+    },
+]);
+
 onMounted(async () => {
     await loadOrderDetails();
 });

--- a/pages/checkout/finish/[id].vue
+++ b/pages/checkout/finish/[id].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 const { params } = useRoute();
+const { checkoutBreadcrumbs } = useStaticBreadcrumbs();
 const orderId = params.id as string;
 const { order, loadOrderDetails, shippingAddress, billingAddress, shippingMethod, paymentMethod, status, total } =
     useOrderDetails(orderId);
@@ -10,20 +11,7 @@ const formattedOrderDate = useDateFormat(order.orderDate, dateFormat, {
     locales: (typeof navigator !== 'undefined' && navigator.language) || 'en-US',
 });
 
-useBreadcrumbs([
-    {
-        name: "Cart",
-        path: "/checkout/cart",
-    },
-    {
-        name: "Checkout",
-        path: "/checkout/confirm",
-    },
-    {
-        name: "Order",
-        path: "/checkout/finish/" + orderId,
-    },
-]);
+useBreadcrumbs(checkoutBreadcrumbs(2, orderId));
 
 onMounted(async () => {
     await loadOrderDetails();

--- a/pages/checkout/finish/[id].vue
+++ b/pages/checkout/finish/[id].vue
@@ -11,7 +11,7 @@ const formattedOrderDate = useDateFormat(order.orderDate, dateFormat, {
     locales: (typeof navigator !== 'undefined' && navigator.language) || 'en-US',
 });
 
-useBreadcrumbs(checkoutBreadcrumbs(2, orderId));
+useBreadcrumbs(checkoutBreadcrumbs({ index: 2, orderId: orderId }));
 
 onMounted(async () => {
     await loadOrderDetails();

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -28,13 +28,8 @@ const productSearch = await loadProducts(cacheKey.value);
 setInitialListing(productSearch.value as Schemas['ProductListingResult']);
 
 useBreadcrumbs([
-    // TODO: Replace with dynamic home page name
     {
-        name: 'Startseite',
-        path: '/'
-    },
-    {
-        name: "Suchergebnisse",
+        name: "Search results",
         path: "/search?search=" + route.query.search,
     },
 ]);

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -29,8 +29,8 @@ setInitialListing(productSearch.value as Schemas['ProductListingResult']);
 
 useBreadcrumbs([
     {
-        name: "Search results",
-        path: "/search?search=" + route.query.search,
+        name: 'Search results',
+        path: '/search?search=' + route.query.search,
     },
 ]);
 </script>

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -26,6 +26,18 @@ const loadProducts = async (cacheKey: string) => {
 const productSearch = await loadProducts(cacheKey.value);
 
 setInitialListing(productSearch.value as Schemas['ProductListingResult']);
+
+useBreadcrumbs([
+    // TODO: Replace with dynamic home page name
+    {
+        name: 'Startseite',
+        path: '/'
+    },
+    {
+        name: "Suchergebnisse",
+        path: "/search?search=" + route.query.search,
+    },
+]);
 </script>
 
 <template>


### PR DESCRIPTION
- Fixes the display of product images in the cart / offcanvas cart
- Fixes order summary not being displayed
- Adds new composable to getProductRoute supporting product, lineItem, orderLineItem objects
- Adds breadcrumbs to product detail page, landing pages and navigation pages
- Adds new staticBreadcrumbs composable to use as a place to define the breadcrumb hierarchy of static pages and add options to them to display them at the right places in the frontend with a single line