### PR TITLE
ICO-83 Fix infinite reload, switch language without refresh and update context

### DIFF
--- a/components/LanguageSwitch.vue
+++ b/components/LanguageSwitch.vue
@@ -2,17 +2,19 @@
 import type { Schemas } from '@shopware/api-client/api-types';
 const { entityArrayToOptions } = useFormkitHelper();
 
-const { languages, getAvailableLanguages, changeLanguage } = useInternationalization();
-const { languageIdChain } = useSessionContext();
+const { locale, setLocale } = useI18n();
+const { languages, getAvailableLanguages, changeLanguage, getLanguageCodeFromId, getLanguageIdFromCode } =
+    useInternationalization();
+const { refreshSessionContext } = useSessionContext();
 await getAvailableLanguages();
 
+const selectedLanguageId = computed(() => getLanguageIdFromCode(locale.value));
+
 const onLanguageChange = async (option: Event) => {
-    const data = await changeLanguage((option.target as HTMLSelectElement).value);
-    if (data.redirectUrl) {
-        window.location.replace(data.redirectUrl);
-    } else {
-        window.location.reload();
-    }
+    const selectedOptionId = (option.target as HTMLSelectElement).value
+    await changeLanguage(selectedOptionId);
+    setLocale(getLanguageCodeFromId(selectedOptionId));
+    await refreshSessionContext();
 };
 
 const languageOptions = computed(() => entityArrayToOptions<Schemas['Language']>(languages.value, 'name', true) ?? []);
@@ -21,7 +23,7 @@ const languageOptions = computed(() => entityArrayToOptions<Schemas['Language']>
 <template>
     <FormKit
         v-if="languages && languages.length > 1"
-        v-model="languageIdChain"
+        v-model="selectedLanguageId"
         type="select"
         name="language"
         prefix-icon="globe"

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,22 +1,4 @@
 <script setup lang="ts">
-// Synchronize the back-end language with the front-end language. This resolves mismatches that can occur, for example,
-// when the language is manually changed in the URL.
-const { changeLanguage, getLanguageCodeFromId, getLanguageIdFromCode } = useInternationalization();
-const { locale } = useI18n();
-const { languageIdChain, refreshSessionContext } = useSessionContext();
-
-watchEffect(async () => {
-    if (languageIdChain.value) {
-        const frontendLocale = locale.value;
-        const backendLocale = getLanguageCodeFromId(languageIdChain.value);
-
-        if (frontendLocale !== backendLocale) {
-            await changeLanguage(getLanguageIdFromCode(frontendLocale));
-            await refreshSessionContext();
-            window.location.reload();
-        }
-    }
-});
 
 const customerStore = useCustomerStore();
 const { loading } = storeToRefs(customerStore);


### PR DESCRIPTION
Fix infinite reload, switch language without refresh and update context.

Using the `languageIdChain` is wrong because 

` const languageIdChain = computed(
    () => sessionContext.value?.context?.languageIdChain?.[0] || "",
  );`
  
  Which is not ok, the language should be set/given by the browser, not the backend. Also when you do the initial request, you get an array of languages and it's wrong to pick the first one, even if you have in the url the second or third language.