### PR TITLE
fix/canonical-urls-origin

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,6 +1,6 @@
 <script setup>
 const { locale } = useI18n();
-const runtimeConfig = useRuntimeConfig();
+const url = useRequestURL()
 const route = useRoute();
 
 useHead(() => ({
@@ -10,7 +10,7 @@ useHead(() => ({
     link: [
         {
             rel: 'canonical',
-            href: runtimeConfig.public.pond.shopwareEndpoint + route.path,
+            href: url.origin + route.path,
         },
     ],
 }));

--- a/components/Cms/Block/CmsBlockGalleryBuybox.vue
+++ b/components/Cms/Block/CmsBlockGalleryBuybox.vue
@@ -14,7 +14,7 @@ const product = inject('productData');
 
 // change the canonical tag if the option is enabled to use the same canonical for all variants
 if (product.value.canonicalProductId && product.value.canonicalProductId !== product.value.id) {
-    const runtimeConfig = useRuntimeConfig();
+    const url = useRequestURL()
     const { getUrlByProductId } = useSeoUrl();
     const canonicalUrl = await getUrlByProductId(product.value.canonicalProductId);
 
@@ -22,7 +22,7 @@ if (product.value.canonicalProductId && product.value.canonicalProductId !== pro
         link: [
             {
                 rel: 'canonical',
-                href: runtimeConfig.public.pond.shopwareEndpoint + canonicalUrl.path,
+                href: url.origin + canonicalUrl.path,
             },
         ],
     }));


### PR DESCRIPTION
use url-origin instead of runtime config for canonicalUrls 
the runtime config was actually the wrong variable to use, because it points to the shopware instance (with our current setup this means the url with "shopware." infront of it)