### PR TITLE
fix/disable-ssr-for-customer-specific-routes

### DIFF
--- a/components/Account/Order/AccountOrderContent.vue
+++ b/components/Account/Order/AccountOrderContent.vue
@@ -91,6 +91,7 @@ onMounted(async () => {
                 :total="totalPages * limit"
                 :items-per-page="limit"
                 :default-page="Number(currentPage)"
+                :page="route.query.page ? Number(route.query.page) : Number(currentPage)"
                 @update-page="page => changePage(page)"
             />
         </ul>

--- a/components/Utility/UtilityStaticNotification.vue
+++ b/components/Utility/UtilityStaticNotification.vue
@@ -22,5 +22,5 @@ const staticNotification: Notification = {
 </script>
 
 <template>
-    <UtilityToastNotification :notification="staticNotification" :persistent="true" />
+    <UtilityToastNotification :notification="staticNotification" />
 </template>

--- a/components/Utility/UtilityToastNotification.vue
+++ b/components/Utility/UtilityToastNotification.vue
@@ -1,15 +1,9 @@
 <script setup lang="ts">
 import type { Notification } from '@shopware-pwa/composables-next';
 
-const props = withDefaults(
-    defineProps<{
-      notification: Notification;
-      persistent?: boolean;
-    }>(),
-    {
-        persistent: false,
-    },
-);
+const props = defineProps<{
+    notification: Notification;
+}>();
 
 const { t } = useI18n();
 

--- a/components/Utility/UtilityToastNotification.vue
+++ b/components/Utility/UtilityToastNotification.vue
@@ -11,7 +11,6 @@ const props = withDefaults(
     },
 );
 
-const { removeOne } = useNotifications();
 const { t } = useI18n();
 
 const iconMap = {
@@ -52,22 +51,5 @@ const icon = computed(() => iconMap[props.notification.type] || 'information');
         <div class="leading-4">
             {{ notification.message }}
         </div>
-
-        <template v-if="persistent">
-            <button
-                type="button"
-                class="ml-auto hover:rounded-md hover:bg-gray-medium hover:ring-4 hover:ring-gray-medium"
-                :data-dismiss-target="`toast-${notification.id}`"
-                :aria-label="$t('utility.toast.closeButtonAriaLabel')"
-                :title="t('icon.close')"
-                @click="removeOne(notification.id)"
-            >
-                <FormKitIcon
-                    icon="xmark"
-                    :title="t('icon.close')"
-                    class="block size-4 text-gray-dark"
-                />
-            </button>
-        </template>
     </div>
 </template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -65,6 +65,9 @@ export default defineNuxtConfig({
     routeRules: {
         '/newsletter-subscribe': { redirect: '/newsletter/confirm' },
         '/registration/confirm': { redirect: '/account/register/confirm' },
+        '/account/**': { ssr: false },
+        '/checkout/**': { ssr: false },
+        '/wishlist/**': { ssr: false },
     },
 
     extends: ['@shopware-pwa/composables-next/nuxt-layer'],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@basecom-gmbh/pond",
   "type": "module",
   "main": "./nuxt.config.ts",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "scripts": {
     "build": "nuxt build",
     "dev": "nuxt dev",

--- a/pages/newsletter/confirm.vue
+++ b/pages/newsletter/confirm.vue
@@ -26,6 +26,10 @@ const hash = route.query.hash as string | null;
 
 onMounted(async () => {
     if (!emailHash || !hash) {
+        notification.value.message = t('cms.element.form.newsletter.noRegisterData');
+        notification.value.type = 'danger';
+
+        isLoading.value = false;
         return;
     }
 

--- a/pages/wishlist.vue
+++ b/pages/wishlist.vue
@@ -25,7 +25,7 @@ const page = ref(route.query.page ? Number(route.query.page) : defaultPage);
 const limit = ref(route.query.limit ? Number(route.query.limit) : defaultLimit);
 
 const { pushSuccess, pushError } = useNotifications();
-const { items: wishlistItems, clearWishlist, getWishlistProducts, currentPage, totalPagesCount, canSyncWishlist } = useWishlist();
+const { items: wishlistItems, clearWishlist, getWishlistProducts, count, currentPage, canSyncWishlist } = useWishlist();
 const { apiClient } = useShopwareContext();
 
 const clearWishlistHandler = async () => {
@@ -151,9 +151,10 @@ await getWishlistProducts({
             >
                 <div class="place-self-center text-center">
                     <LayoutPagination
-                        :total="totalPagesCount"
+                        :total="count"
                         :items-per-page="limit"
                         :default-page="Number(currentPage)"
+                        :page="route.query.page ? Number(route.query.page) : Number(currentPage)"
                         @update-page="page => changePage(page)"
                     />
                 </div>


### PR DESCRIPTION
- disable SSR for /account, /checkout and /wishlist routes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the app version to 0.1.11.
- **Refactor**
  - Changed the rendering strategy for all pages under /account, /checkout, and /wishlist to client-side rendering.
- **UI Enhancements**
  - Improved wishlist pagination by aligning total item count with the new `count` property.
  - Synchronised order list pagination with URL query parameters for better navigation consistency.
- **UI Enhancements**
  - Removed the `persistent` property from toast notifications, affecting their dismissal behavior.
  - Updated notification handling on newsletter confirmation page for missing data alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->